### PR TITLE
Change TestCall.message DB column type to DataType.TEXT

### DIFF
--- a/server/src/test-call/test-call.model.ts
+++ b/server/src/test-call/test-call.model.ts
@@ -2,6 +2,7 @@ import { Broadcast } from '../broadcast/broadcast.model';
 
 import {
   Column,
+  DataType,
   ForeignKey,
   Model,
   PrimaryKey,
@@ -17,7 +18,7 @@ export class TestCall extends Model<TestCall> {
   to!: string;
   @Column
   from!: string;
-  @Column
+  @Column(DataType.TEXT)
   message!: string;
   @Column
   status!: string;


### PR DESCRIPTION
**Issue**: https://github.com/twilio/twilio-voice-notification-app/issues/1

This PR changes the type of the message column of the TestCall table from VARCHAR(255) to TEXT so that it is consistent with the Broadcast limits. (up to 3000 chars)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
