### PR TITLE
Remove unnecessary twiml message usages

### DIFF
--- a/server/src/broadcast/broadcast.service.ts
+++ b/server/src/broadcast/broadcast.service.ts
@@ -5,7 +5,6 @@ import { AuthGuard } from '../guards/auth.guard';
 import { Call } from '../call/call.model';
 import { BroadcastMeta } from '../types/broadcast-meta';
 import { v4 as uuidv4 } from 'uuid';
-import * as VoiceResponse from 'twilio/lib/twiml/VoiceResponse';
 import { TwilioService } from '../twilio/twilio.service';
 import { CallInstance } from 'twilio/lib/rest/api/v2010/account/call';
 import { Logger } from '@nestjs/common';
@@ -26,14 +25,6 @@ export class BroadcastService {
     private callModel: typeof Call,
     private readonly twilioService: TwilioService,
   ) {}
-
-  private getTwimlMessage(message: string): string {
-    const twiml = new VoiceResponse();
-    twiml.pause({ length: 2 });
-    twiml.say(message);
-
-    return twiml.toString();
-  }
 
   async create(
     friendlyName: string,
@@ -65,8 +56,6 @@ export class BroadcastService {
     recipients: string[],
     statusCallback: string,
   ) {
-    const twiml = this.getTwimlMessage(message);
-
     const makeCalls = recipients.map((to) => {
       return new Promise(async (resolve, reject) => {
 
@@ -82,7 +71,7 @@ export class BroadcastService {
             statusCallback,
             to,
             from,
-            twiml,
+            message,
           ));
         } catch (error) {
           Logger.error(`There was an error creating a call for: ${to}. Error ${error.message}`);

--- a/server/src/test-call/test-call.service.ts
+++ b/server/src/test-call/test-call.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { TestCall } from './test-call.model';
 import { InjectModel } from '@nestjs/sequelize';
 import { TestCallGateway } from './test-call.gateway';
-import { twiml as Twiml } from 'twilio';
 import { TwilioService } from '../twilio/twilio.service';
 
 @Injectable()
@@ -20,9 +19,6 @@ export class TestCallService {
     message: string,
     statusCallback: string,
   ): Promise<{ callSid: string }> {
-    const twiml = new Twiml.VoiceResponse();
-    twiml.say(message);
-
     const { callSid, status } = await this.twilioService.createCall(
       statusCallback,
       to,


### PR DESCRIPTION
Twiml generation is already taken care by twilio.service. Usages in broadcast.service and test-call.service are not needed and make the code cumbersome and less DRY.

Thanks @dkundel for spotting it

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
